### PR TITLE
Does not depend request parameter for Child#user_id

### DIFF
--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -57,7 +57,7 @@ class ChildrenController < ApplicationController
   private
 
   def child_params
-    params.require(:child).permit(:nick_name, :birthday, :avatar, :comment, :child_number, :user_id)
+    params.require(:child).permit(:nick_name, :birthday, :avatar, :comment, :child_number).merge(user_id: current_user.id)
   end
 
   def set_child


### PR DESCRIPTION
セキュリティ系の情報なので Github 経由が良いか迷ったのですが、習作アプリのようなのでこちらで報告させてください

子供の情報を編集する機能がPOSTパラメータに完全依存しているため、curl等使うと他人のお子さんの情報も変更できてしまいます。

僕の user.id は 118 ですが、下記2名のお子さんを「u」に変更・追加できてしまいました。

<img width="937" alt="スクリーンショット 2021-02-14 5 22 28" src="https://user-images.githubusercontent.com/1180335/107860843-25464500-6e85-11eb-92bd-0db500259ff9.png">
<img width="878" alt="スクリーンショット 2021-02-14 5 22 39" src="https://user-images.githubusercontent.com/1180335/107860844-27a89f00-6e85-11eb-906b-34fcfa974e86.png">

動作確認は出来ていませんが、概ねこのPRのような変更を入れれば直るかと思います。
