### PR TITLE
Add missing step to development

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ __URL：__　https://www.sukusuku-app.com/
 ```
 $ git clone https://github.com/SHOGOHORI/sukusuku_ver2.git
 $ cd sukusuku_ver2
+$ touch .env
 $ docker-compose build
 $ docker-compose up -d
 $ docker-compose run web rails db:create


### PR DESCRIPTION
この行がないと、 `docker-compose build` を叩いても

```
WARNING: The DB_ROOT_PASSWORD variable is not set. Defaulting to a blank string.
WARNING: The DB_USER variable is not set. Defaulting to a blank string.
WARNING: The DB_PASSWORD variable is not set. Defaulting to a blank string.
ERROR: Couldn't find env file: /Users/kachick/repos/sukusuku_ver2/.env
```

というエラーが出て先に進めませんでした。