### PR TITLE
Prevent to post/destroy votes from another user

### DIFF
--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -1,4 +1,7 @@
 class VotesController < ApplicationController
+  before_action :set_vote, only: [:show, :destroy]
+  before_action :redirect_root, only: [:destroy]
+
   impressionist actions: [:show]
 
   def new
@@ -19,7 +22,6 @@ class VotesController < ApplicationController
 
   def show
     store_location
-    @vote = Vote.find(params[:id])
     @stock = VoteStock.new
     impressionist(@vote, nil, unique: [:session_hash])
     @vote_relationship = VoteRelationship.new
@@ -37,7 +39,6 @@ class VotesController < ApplicationController
   end
 
   def destroy
-    @vote = Vote.find(params[:id])
     @vote.destroy
     redirect_to root_path, notice: '削除しました'
   end
@@ -45,10 +46,18 @@ class VotesController < ApplicationController
   private
 
   def vote_params
-    params.require(:vote).permit(:content, :title, :user_id, :category_id, :age, :moon_age, :pregnant, :closed_at, { image: [] }, :days, vote_items_attributes: [:item, :item_number])
+    params.require(:vote).permit(:content, :title, :category_id, :age, :moon_age, :pregnant, :closed_at, { image: [] }, :days, vote_items_attributes: [:item, :item_number]).merge(user_id: current_user.id)
   end
 
   def store_location
     session[:forwarding_url] = request.original_url if request.get?
+  end
+
+  def set_vote
+    @vote = Vote.find(params[:id])
+  end
+
+  def redirect_root
+    redirect_to(root_url) unless current_user.id == @vote.user_id
   end
 end


### PR DESCRIPTION
軽くコードを読んだ限り投票機能にも https://github.com/SHOGOHORI/sukusuku_ver2/pull/106 https://github.com/SHOGOHORI/sukusuku_ver2/pull/110 と似たようなセキュリティホールがありそうだったので試してみたらやはり出来てしまいました。

<img width="1140" alt="スクリーンショット 2021-02-14 6 31 31" src="https://user-images.githubusercontent.com/1180335/107862348-a99dc580-6e8f-11eb-818c-31f84133e32a.png">

user 118 が user 113 を騙って投稿できます。
他人分の削除も出来てしまいそうなのでまとめて修正してみましたが、なにぶん https://github.com/SHOGOHORI/sukusuku_ver2/issues/108 の影響で動作確認が取れていません。 🙏 